### PR TITLE
Dataservice patch capability

### DIFF
--- a/.bumpversion
+++ b/.bumpversion
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.7
+current_version = 1.4.8
 allow_dirty = True
 
 [bumpversion:file:VERSION]

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 # Do not update directly, use `make bump-version` instead or see `README.md` for further instructions
-1.4.7
+1.4.8

--- a/project/package.json
+++ b/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movici-flow-lib",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "private": true,
   "scripts": {
     "test:unit": "vitest",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,6 +4,7 @@ export enum CAPABILITIES {
   USER = "user",
   GEOCODE = "geocode",
   PROJECTS = "projects",
+  EDITOR = "patchDatasets",
 }
 
 export { Client };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,7 +4,7 @@ export enum CAPABILITIES {
   USER = "user",
   GEOCODE = "geocode",
   PROJECTS = "projects",
-  EDITOR = "patchDatasets",
+  PATCH_DATASETS = "patchDatasets",
 }
 
 export { Client };

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -94,7 +94,6 @@ export interface FetchRequestService {
   ): { url: string; options: RequestInit };
 }
 
-// The dataset editor is gated by "patchDatasets" (exposed as CAPABILITIES.EDITOR).
 export type BackendCapability = "projects" | "geocode" | "user" | "patchDatasets";
 
 export interface Backend {

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -17,6 +17,7 @@ import type {
   GeocodeSuggestion,
   ViewPayload,
 } from "@movici-flow-lib/types";
+import { DatasetCrudResponse } from "./api";
 
 export interface ViewService {
   create(scenarioUUID: UUID, view: ViewPayload): Promise<ViewCrudResponse | null>;
@@ -75,6 +76,15 @@ export interface DatasetService {
   getMetaData: (datasetUUID: UUID) => Promise<Dataset | null>;
 }
 
+export interface DatasetPatch {
+  data: Record<string, Record<string, unknown[]>>;
+  deleted?: Record<string, number[]>;
+}
+
+export interface DatasetEditorService {
+  patch(datasetUUID: UUID, patch: DatasetPatch): Promise<DatasetCrudResponse | null>;
+}
+
 export interface UserService {
   get(): Promise<User | null>;
 }
@@ -90,10 +100,12 @@ export interface FetchRequestService {
   ): { url: string; options: RequestInit };
 }
 
-export type BackendCapability = "projects" | "geocode" | "user";
+export type BackendCapability = "projects" | "geocode" | "user" | "editor" | "patchDatasets";
+
 export interface Backend {
   getCapabilities(): BackendCapability[];
   dataset: DatasetService;
+  datasetEditor?: DatasetEditorService;
   geocode: GeocodeService;
   project: ProjectService;
   scenario: ScenarioService;

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -9,6 +9,7 @@ import type {
   DataAttribute,
   Update,
   UpdateWithData,
+  DatasetPatch,
   UUID,
   View,
   ViewCrudResponse,
@@ -17,7 +18,6 @@ import type {
   GeocodeSuggestion,
   ViewPayload,
 } from "@movici-flow-lib/types";
-import { DatasetCrudResponse } from "./api";
 
 export interface ViewService {
   create(scenarioUUID: UUID, view: ViewPayload): Promise<ViewCrudResponse | null>;
@@ -74,15 +74,9 @@ export interface DatasetService {
   getState<T>(params: GetStateParams): Promise<DatasetWithData<T> | null>;
 
   getMetaData: (datasetUUID: UUID) => Promise<Dataset | null>;
-}
 
-export interface DatasetPatch {
-  data: Record<string, Record<string, unknown[]>>;
-  deleted?: Record<string, number[]>;
-}
-
-export interface DatasetEditorService {
-  patch(datasetUUID: UUID, patch: DatasetPatch): Promise<DatasetCrudResponse | null>;
+  // Capability for data editor.
+  patch?(datasetUUID: UUID, patch: DatasetPatch): Promise<void>;
 }
 
 export interface UserService {
@@ -106,7 +100,6 @@ export type BackendCapability = "projects" | "geocode" | "user" | "patchDatasets
 export interface Backend {
   getCapabilities(): BackendCapability[];
   dataset: DatasetService;
-  datasetEditor?: DatasetEditorService;
   geocode: GeocodeService;
   project: ProjectService;
   scenario: ScenarioService;

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -100,7 +100,8 @@ export interface FetchRequestService {
   ): { url: string; options: RequestInit };
 }
 
-export type BackendCapability = "projects" | "geocode" | "user" | "editor" | "patchDatasets";
+// The dataset editor is gated by "patchDatasets" (exposed as CAPABILITIES.EDITOR).
+export type BackendCapability = "projects" | "geocode" | "user" | "patchDatasets";
 
 export interface Backend {
   getCapabilities(): BackendCapability[];

--- a/src/types/datasets.ts
+++ b/src/types/datasets.ts
@@ -79,7 +79,7 @@ export interface DatasetData<T> {
 }
 
 export interface DatasetPatch {
-  data: Record<string, Record<string, unknown[]>>;
+  data: DatasetData<unknown>;
   deleted?: Record<string, number[]>;
 }
 

--- a/src/types/datasets.ts
+++ b/src/types/datasets.ts
@@ -78,6 +78,11 @@ export interface DatasetData<T> {
   [entityGroup: string]: EntityGroupData<T>;
 }
 
+export interface DatasetPatch {
+  data: Record<string, Record<string, unknown[]>>;
+  deleted?: Record<string, number[]>;
+}
+
 export interface BaseEntityGroup {
   id: number[];
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = "1.4.7";
+const version = "1.4.8";
 export { version };


### PR DESCRIPTION
Describe your changes
--------------------
Extends the DatasetService to enable patching dataset. This will enable editing dataset in the dataset editor.

- Adds `patchDatsets` capability to the API.
- Adds backend types.
- Adds an interface for patching datasets.
- Bumps up version to: 1.4.8
- Closes #31 

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution

P.S. **GUI components for the dataset editor itself will follow in a different PR.**